### PR TITLE
IDE Dark theme support.

### DIFF
--- a/Packages/DelphiRefactoringLight.dpk
+++ b/Packages/DelphiRefactoringLight.dpk
@@ -23,6 +23,7 @@ package DelphiRefactoringLight;
 {$WRITEABLECONST OFF}
 {$MINENUMSIZE 1}
 {$IMAGEBASE $400000}
+{$DEFINE DEBUG}
 {$ENDIF IMPLICITBUILDING}
 {$DESCRIPTION 'Delphi Refactoring Light - Rename / Find References / Extract Method via DelphiLSP'}
 {$LIBSUFFIX AUTO}
@@ -47,6 +48,7 @@ contains
   Rename.WorkspaceEdit in '..\Source\Rename.WorkspaceEdit.pas',
   Delphi.FileEncoding in '..\Source\Delphi.FileEncoding.pas',
   Expert.Shortcuts in '..\Source\Expert.Shortcuts.pas',
+  Expert.IdeThemes in '..\Source\Expert.IdeThemes.pas',
   Expert.LspManager in '..\Source\Expert.LspManager.pas',
   Expert.IdeCodeInsight in '..\Source\Expert.IdeCodeInsight.pas',
   Expert.CompletionPopup in '..\Source\Expert.CompletionPopup.pas',

--- a/Source/Expert.CompletionPopup.pas
+++ b/Source/Expert.CompletionPopup.pas
@@ -72,6 +72,9 @@ type
 
 implementation
 
+uses
+  Expert.IdeThemes;
+
 { TCompletionItems }
 
 class function TCompletionItems.KindToPrefix(AKind: Integer): string;
@@ -152,7 +155,7 @@ begin
   FormStyle := fsStayOnTop;
   Width := 450;
   Height := 320;
-  Color := clWindow;
+  Color := GetThemedColor(clWindow);
   OnDeactivate := DoFormDeactivate;
 
   FFilteredItems := TList<TCompletionItem>.Create;
@@ -174,7 +177,7 @@ begin
   FDetailLabel.Height := 22;
   FDetailLabel.Font.Name := 'Consolas';
   FDetailLabel.Font.Size := 9;
-  FDetailLabel.Font.Color := clGray;
+  FDetailLabel.Font.Color := GetThemedColor(clGrayText);
   FDetailLabel.AutoSize := False;
   FDetailLabel.Caption := '';
   FDetailLabel.Layout := tlCenter;
@@ -190,6 +193,8 @@ begin
   FListBox.OnDblClick := DoListBoxDblClick;
   FListBox.OnKeyDown := DoKeyDown;
   FListBox.OnDrawItem := DoListBoxDrawItem;
+
+  Expert.IdeThemes.EnableThemes(Self);
 end;
 
 destructor TCompletionPopup.Destroy;
@@ -301,25 +306,25 @@ begin
 
   // Hintergrund
   if odSelected in State then
-    Canvas.Brush.Color := clHighlight
+    Canvas.Brush.Color := GetThemedColor(clHighlight)
   else
-    Canvas.Brush.Color := clWindow;
+    Canvas.Brush.Color := GetThemedColor(clWindow);
   Canvas.FillRect(Rect);
 
   // Kind-Prefix (farbig)
   Prefix := TCompletionItems.KindToPrefix(Item.Kind);
   if odSelected in State then
-    Canvas.Font.Color := clHighlightText
+    Canvas.Font.Color := GetThemedColor(clHighlightText)
   else
-    Canvas.Font.Color := clGray;
+    Canvas.Font.Color := GetThemedColor(clGrayText);
   Canvas.Font.Style := [];
   Canvas.TextOut(Rect.Left + 4, Rect.Top + 2, Prefix);
 
   // Label
   if odSelected in State then
-    Canvas.Font.Color := clHighlightText
+    Canvas.Font.Color := GetThemedColor(clHighlightText)
   else
-    Canvas.Font.Color := clWindowText;
+    Canvas.Font.Color := GetThemedColor(clWindowText);
   Canvas.Font.Style := [fsBold];
   LabelText := Item.Label_;
   Canvas.TextOut(Rect.Left + 44, Rect.Top + 2, LabelText);
@@ -329,9 +334,9 @@ begin
   begin
     DetailText := Item.Detail;
     if odSelected in State then
-      Canvas.Font.Color := clHighlightText
+      Canvas.Font.Color := GetThemedColor(clHighlightText)
     else
-      Canvas.Font.Color := clGray;
+      Canvas.Font.Color := GetThemedColor(clGrayText);
     Canvas.Font.Style := [];
     Canvas.TextOut(Rect.Left + 46 + Canvas.TextWidth(LabelText) + 8,
       Rect.Top + 2, DetailText);

--- a/Source/Expert.ExtractMethodDialog.pas
+++ b/Source/Expert.ExtractMethodDialog.pas
@@ -54,7 +54,8 @@ type
 implementation
 
 uses
-  System.IOUtils, Vcl.Graphics;
+  System.IOUtils, Vcl.Graphics,
+  Expert.IdeThemes;
 
 constructor TExtractMethodDialog.CreateDialog(AOwner: TComponent; const ADefaultName: string);
 begin
@@ -161,6 +162,7 @@ begin
   FMemoPreview.Font.Size := 9;
   FMemoPreview.WordWrap := False;
 
+  Expert.IdeThemes.EnableThemes(Self);
   FIndex := TProjectTextIndex.Create;
 end;
 
@@ -192,7 +194,7 @@ begin
   FCheckTimer.Enabled := False;
   if FCurrentFile <> '' then
   begin
-    FLblNameCheck.Font.Color := clGrayText;
+    FLblNameCheck.Font.Color := GetThemedColor(clGrayText);
     FLblNameCheck.Caption := 'Checking...';
     FCheckTimer.Enabled := True;
   end;
@@ -203,7 +205,7 @@ begin
   FCheckTimer.Enabled := False;
   if not FIndex.PollReady then
   begin
-    FLblNameCheck.Font.Color := clGrayText;
+    FLblNameCheck.Font.Color := GetThemedColor(clGrayText);
     FLblNameCheck.Font.Style := [];
     FLblNameCheck.Caption := 'Indexing project for collision check...';
     FCheckTimer.Interval := 200;

--- a/Source/Expert.FindReferencesDialog.pas
+++ b/Source/Expert.FindReferencesDialog.pas
@@ -62,7 +62,7 @@ type
 implementation
 
 uses
-  System.IOUtils;
+  System.IOUtils, Expert.IdeThemes;
 
 { TFindReferencesDialog }
 
@@ -81,6 +81,7 @@ begin
   OnKeyDown := DoFormKeyDown;
 
   CreateControls;
+  Expert.IdeThemes.EnableThemes(Self);
 end;
 
 procedure TFindReferencesDialog.CreateControls;

--- a/Source/Expert.IdeThemes.pas
+++ b/Source/Expert.IdeThemes.pas
@@ -1,0 +1,76 @@
+unit Expert.IdeThemes;
+
+interface
+
+uses
+  System.UITypes,
+  Vcl.Controls,
+  Vcl.Forms;
+
+//function IdeThemesEnabled: Boolean;
+//function IsDarkMode: Boolean;
+function GetThemedColor(AColor: TColor): TColor;
+procedure EnableThemes(AForm: TCustomForm);
+
+implementation
+
+uses
+  ToolsApi,
+  System.SysUtils;
+
+function IdeThemesEnabled: Boolean;
+var
+  Service: IOTAIDEThemingServices;
+begin
+  if Supports(BorlandIDEServices, IOTAIDEThemingServices, Service) then
+  begin
+    Result := Service.IDEThemingEnabled
+  end
+  else
+    Result := False;
+end;
+
+function IsDarkMode: Boolean;
+var
+  Service: IOTAIDEThemingServices;
+begin
+  Result := False;
+  if Supports(BorlandIDEServices, IOTAIDEThemingServices, Service) then
+  begin
+    if Service.IDEThemingEnabled then
+    begin
+      Result := Service.ActiveTheme.Contains('Dark', True);
+    end;
+  end;
+end;
+
+procedure EnableThemes(AForm: TCustomForm);
+var
+  Service: IOTAIDEThemingServices;
+begin
+  if Supports(BorlandIDEServices, IOTAIDEThemingServices, Service) then
+  begin
+    if Service.IDEThemingEnabled then
+    begin
+      Service.RegisterFormClass(TCustomFormClass(AForm.ClassType));
+      Service.ApplyTheme(AForm);
+    end;
+  end;
+end;
+
+function GetThemedColor(AColor: TColor): TColor;
+var
+  Service: IOTAIDEThemingServices;
+begin
+  if Supports(BorlandIDEServices, IOTAIDEThemingServices, Service) then
+  begin
+    if (Service.IDEThemingEnabled) and Assigned(Service.StyleServices) then
+      Result := Service.StyleServices.GetSystemColor(AColor)
+    else
+      Result := AColor;
+  end
+  else
+    Result := AColor;
+end;
+
+end.

--- a/Source/Expert.RenameDialog.pas
+++ b/Source/Expert.RenameDialog.pas
@@ -98,7 +98,8 @@ type
 implementation
 
 uses
-  System.UITypes, System.IOUtils, Vcl.Graphics, Winapi.UxTheme;
+  System.UITypes, System.IOUtils, Vcl.Graphics, Winapi.UxTheme,
+  Expert.IdeThemes;
 
 constructor TRenameDialog.CreateDialog(AOwner: TComponent; const AOldName: string);
 var
@@ -293,6 +294,7 @@ begin
   FMemoDetails.WordWrap := False;
 
   FPageControl.ActivePage := FTabChanges;
+  Expert.IdeThemes.EnableThemes(Self);
 
   FIndex := TProjectTextIndex.Create;
 end;
@@ -326,7 +328,7 @@ begin
   FCheckTimer.Enabled := False;
   if FCurrentFile <> '' then
   begin
-    FLblNameCheck.Font.Color := clGrayText;
+    FLblNameCheck.Font.Color := GetThemedColor(clGrayText);
     FLblNameCheck.Caption := 'Checking...';
     FCheckTimer.Enabled := True;
   end;
@@ -337,7 +339,7 @@ begin
   FCheckTimer.Enabled := False;
   if not FIndex.PollReady then
   begin
-    FLblNameCheck.Font.Color := clGrayText;
+    FLblNameCheck.Font.Color := GetThemedColor(clGrayText);
     FLblNameCheck.Font.Style := [];
     FLblNameCheck.Caption := 'Indexing project for collision check...';
     FCheckTimer.Interval := 200;
@@ -357,7 +359,7 @@ begin
 
   case Res.Status of
     icsOk:        FLblNameCheck.Font.Color := clGreen;
-    icsUnchanged: FLblNameCheck.Font.Color := clGrayText;
+    icsUnchanged: FLblNameCheck.Font.Color := GetThemedColor(clGrayText);
     icsInProject: FLblNameCheck.Font.Color := $00008CFF; // orange-ish
   else
     FLblNameCheck.Font.Color := clRed;

--- a/Source/Expert.SignatureCheckDialog.pas
+++ b/Source/Expert.SignatureCheckDialog.pas
@@ -55,7 +55,7 @@ type
 implementation
 
 uses
-  Winapi.UxTheme;
+  Winapi.UxTheme, Expert.IdeThemes;
 
 { TSignatureCheckDialog }
 
@@ -75,6 +75,7 @@ begin
   OnKeyDown := DoFormKeyDown;
 
   CreateControls;
+  Expert.IdeThemes.EnableThemes(Self);
 end;
 
 procedure TSignatureCheckDialog.CreateControls;
@@ -240,7 +241,7 @@ begin
     if FEntries[Item.Index].Normalized <> FReferenceNormalized then
       Sender.Canvas.Brush.Color := RGB(255, 230, 230)  // light red
     else
-      Sender.Canvas.Brush.Color := clWindow;
+      Sender.Canvas.Brush.Color := GetThemedColor(clWindow);
   end;
   DefaultDraw := True;
 end;


### PR DESCRIPTION
Added Expert.IdeThemes.pas which provides
- EnableThemes(): Let the IDE customize controls for Light/Dark theme
- GetThemedColor(): Convert system color constants like clWindow, clBtnFace to the color used in current IDE theme.
- Modified existing dialogs to call EnableThemes()