### PR TITLE
Add Find Original Symbol because Ctrl + Click not always works in Delphi 13.1

### DIFF
--- a/Packages/DelphiRefactoringLight.dpk
+++ b/Packages/DelphiRefactoringLight.dpk
@@ -62,6 +62,7 @@ contains
   Expert.FindReferencesWizard in '..\Source\Expert.FindReferencesWizard.pas',
   Expert.ImplementationFinder in '..\Source\Expert.ImplementationFinder.pas',
   Expert.FindImplementationsWizard in '..\Source\Expert.FindImplementationsWizard.pas',
+  Expert.FindOriginalSymbolWizard in '..\Source\Expert.FindOriginalSymbolWizard.pas',
   Expert.ContextMenu in '..\Source\Expert.ContextMenu.pas',
   Expert.UnitRenameWatcher in '..\Source\Expert.UnitRenameWatcher.pas',
   Expert.PluginSettings in '..\Source\Expert.PluginSettings.pas',

--- a/Source/Expert.ContextMenu.pas
+++ b/Source/Expert.ContextMenu.pas
@@ -133,15 +133,10 @@ uses
   Expert.RenameWizard, Expert.CompletionWizard, Expert.ExtractMethod,
   Expert.FindReferencesWizard, Expert.FindImplementationsWizard,
   Expert.SignatureCheckWizard, Expert.WithRefactorWizard, Expert.UnitReferencesWizard,
-<<<<<<< HEAD
   Expert.MoveToUnitWizard, Expert.ExtractInterfaceWizard,
   Expert.SemanticReplaceWizard, Expert.DfmEventCheckDialog,
   Expert.InterfaceGuidDialog, Expert.CircularRefsDialog,
-  Expert.FindUnitDialog;
-=======
-  Expert.MoveToUnitWizard, Expert.FindOriginalSymbolWizard,
-  Expert.ExtractInterfaceWizard, Expert.SemanticReplaceWizard;
->>>>>>> c72e495 (Add Find Original Symbol because Ctrl + Click not always works in Delphi 13.1)
+  Expert.FindUnitDialog, Expert.FindOriginalSymbolWizard;
 
 const
   /// <summary>Maximum retry attempts when the editor popup is not yet

--- a/Source/Expert.ContextMenu.pas
+++ b/Source/Expert.ContextMenu.pas
@@ -78,6 +78,7 @@ type
     procedure OnUnitRefs(Sender: TObject);
     procedure OnFindUnit(Sender: TObject);
     procedure OnMoveToUnit(Sender: TObject);
+    procedure OnFindOriginalSymbol(Sender: TObject);
     procedure OnExtractInterface(Sender: TObject);
     procedure OnAddToExistingInterface(Sender: TObject);
     procedure OnDelegateInterface(Sender: TObject);
@@ -132,10 +133,15 @@ uses
   Expert.RenameWizard, Expert.CompletionWizard, Expert.ExtractMethod,
   Expert.FindReferencesWizard, Expert.FindImplementationsWizard,
   Expert.SignatureCheckWizard, Expert.WithRefactorWizard, Expert.UnitReferencesWizard,
+<<<<<<< HEAD
   Expert.MoveToUnitWizard, Expert.ExtractInterfaceWizard,
   Expert.SemanticReplaceWizard, Expert.DfmEventCheckDialog,
   Expert.InterfaceGuidDialog, Expert.CircularRefsDialog,
   Expert.FindUnitDialog;
+=======
+  Expert.MoveToUnitWizard, Expert.FindOriginalSymbolWizard,
+  Expert.ExtractInterfaceWizard, Expert.SemanticReplaceWizard;
+>>>>>>> c72e495 (Add Find Original Symbol because Ctrl + Click not always works in Delphi 13.1)
 
 const
   /// <summary>Maximum retry attempts when the editor popup is not yet
@@ -264,6 +270,7 @@ begin
   Leaf(Root, 'Rename...',                 OnRename,               skRename,     REQ_EDITOR);
   Leaf(Root, 'Find References',           OnFindReferences,       skFindRef,    REQ_EDITOR);
   Leaf(Root, 'Find Implementations',      OnFindImplementations,  skFindImp,    REQ_EDITOR);
+  Leaf(Root, 'Find Original Symbol',      OnFindOriginalSymbol,   skFindOriginalSymbol, REQ_EDITOR);
   Leaf(Root, 'Extract Method',            OnExtractMethod,        skExtract,    REQ_EDITOR);
   Leaf(Root, 'Align method signature...', OnSignatureCheck,       skAlign,      REQ_EDITOR);
   Leaf(Root, 'Code Completion',           OnCompletion,           skCompletion, REQ_EDITOR);
@@ -907,6 +914,12 @@ procedure TContextMenuInstaller.OnMoveToUnit(Sender: TObject);
 begin
   if MoveToUnitInstance <> nil then
     MoveToUnitInstance.Execute;
+end;
+
+procedure TContextMenuInstaller.OnFindOriginalSymbol(Sender: TObject);
+begin
+  if FindOriginalSymbolInstance <> nil then
+    FindOriginalSymbolInstance.Execute;
 end;
 
 procedure TContextMenuInstaller.OnExtractInterface(Sender: TObject);

--- a/Source/Expert.FindOriginalSymbolWizard.pas
+++ b/Source/Expert.FindOriginalSymbolWizard.pas
@@ -95,8 +95,6 @@ begin
   if RootPath = '' then
     RootPath := ExtractFilePath(FContext.FileName);
 
-  Editor.SaveAllFiles;
-
   Screen.Cursor := crHourGlass;
   try
     WasRunning := TLspManager.Instance.IsAlive;

--- a/Source/Expert.FindOriginalSymbolWizard.pas
+++ b/Source/Expert.FindOriginalSymbolWizard.pas
@@ -1,0 +1,135 @@
+(*
+ * Copyright (c) 2026 Sebastian Jänicke (github.com/jaenicke)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *)
+unit Expert.FindOriginalSymbolWizard;
+
+interface
+
+uses
+  System.SysUtils, System.Classes, Vcl.Forms, Vcl.Dialogs, Vcl.Controls,
+  {$IFNDEF STANDALONE_BUILD}ToolsAPI,{$ENDIF}
+  Expert.EditorHelperIntf, Expert.LspManager, Lsp.Uri, Lsp.Protocol, Lsp.Client;
+
+type
+  TLspFindOriginalSymbolWizard = class{$IFNDEF STANDALONE_BUILD}(TNotifierObject, IOTAWizard, IOTAMenuWizard){$ENDIF}
+  private
+    FContext: TEditorContext;
+    procedure SearchAndGo;
+  public
+    {$IFNDEF STANDALONE_BUILD}
+    procedure AfterSave;
+    procedure BeforeSave;
+    procedure Destroyed;
+    procedure Modified;
+    function GetIDString: string;
+    function GetName: string;
+    function GetState: TWizardState;
+    function GetMenuText: string;
+    {$ENDIF}
+    procedure Execute;
+  end;
+
+var
+  FindOriginalSymbolInstance: TLspFindOriginalSymbolWizard;
+
+implementation
+
+{$IFNDEF STANDALONE_BUILD}
+procedure TLspFindOriginalSymbolWizard.AfterSave; begin end;
+procedure TLspFindOriginalSymbolWizard.BeforeSave; begin end;
+procedure TLspFindOriginalSymbolWizard.Destroyed; begin end;
+procedure TLspFindOriginalSymbolWizard.Modified; begin end;
+
+function TLspFindOriginalSymbolWizard.GetIDString: string;
+begin Result := 'DelphiRefactoringLight.FindOriginalSymbolWizard'; end;
+
+function TLspFindOriginalSymbolWizard.GetName: string;
+begin Result := 'Delphi Refactoring Light - Find Original Symbol'; end;
+
+function TLspFindOriginalSymbolWizard.GetState: TWizardState;
+begin Result := [wsEnabled]; end;
+
+function TLspFindOriginalSymbolWizard.GetMenuText: string;
+begin Result := 'Find Original Symbol...'; end;
+{$ENDIF}
+
+procedure TLspFindOriginalSymbolWizard.Execute;
+var
+  Ctx: TEditorContext;
+begin
+  Ctx := Editor.GetCurrentContext;
+
+  if not Ctx.IsValid then
+  begin
+    MessageDlg('No identifier found at the cursor.' + sLineBreak +
+      'Please place the cursor on an identifier.',
+      mtWarning, [mbOK], 0);
+    Exit;
+  end;
+
+  FContext := Ctx;
+  SearchAndGo;
+end;
+
+procedure TLspFindOriginalSymbolWizard.SearchAndGo;
+var
+  DelphiLspJson, RootPath: string;
+  Client: TLspClient;
+  Defs: TArray<TLspLocation>;
+  WasRunning: Boolean;
+begin
+  DelphiLspJson := Editor.FindDelphiLspJson;
+  if DelphiLspJson = '' then
+  begin
+    MessageDlg('No .delphilsp.json found.' + sLineBreak +
+      'Enable Tools > Options > Editor > Language > Code Insight > "Generate LSP Config".',
+      mtError, [mbOK], 0);
+    Exit;
+  end;
+
+  RootPath := FContext.ProjectRoot;
+  if RootPath = '' then
+    RootPath := ExtractFilePath(FContext.FileName);
+
+  Editor.SaveAllFiles;
+
+  Screen.Cursor := crHourGlass;
+  try
+    WasRunning := TLspManager.Instance.IsAlive;
+    Client := TLspManager.Instance.GetClient(RootPath, FContext.ProjectFile, DelphiLspJson);
+    Client.RefreshDocument(FContext.FileName);
+
+    if not WasRunning then
+    begin
+      for var Retry := 1 to 30 do
+      begin
+        try
+          var H := Client.GetHover(FContext.FileName, FContext.Line - 1, FContext.Column - 1);
+          if H <> '' then Break;
+        except end;
+        Sleep(1000);
+      end;
+    end;
+
+    Defs := Client.GotoDefinition(FContext.FileName, FContext.Line - 1, FContext.Column - 1);
+    if Length(Defs) > 0 then
+    begin
+      var DefPath := TLspUri.FileUriToPath(Defs[0].Uri);
+      Editor.GotoLocation(DefPath,
+        Defs[0].Range.Start.Line, Defs[0].Range.Start.Character,
+        System.Length(FContext.WordAtCursor));
+    end
+    else
+      MessageDlg('Original symbol not found.' + sLineBreak +
+        'Could not determine the definition of "' + FContext.WordAtCursor + '".',
+        mtInformation, [mbOK], 0);
+  finally
+    Screen.Cursor := crDefault;
+  end;
+end;
+
+end.

--- a/Source/Expert.KeyBinding.pas
+++ b/Source/Expert.KeyBinding.pas
@@ -24,6 +24,7 @@ type
     procedure RemoveWithKeyProc(const Context: IOTAKeyContext; KeyCode: TShortCut; var BindingResult: TKeyBindingResult);
     procedure UnitRefsKeyProc(const Context: IOTAKeyContext; KeyCode: TShortCut; var BindingResult: TKeyBindingResult);
     procedure MoveToUnitKeyProc(const Context: IOTAKeyContext; KeyCode: TShortCut; var BindingResult: TKeyBindingResult);
+    procedure FindOriginalSymbolKeyProc(const Context: IOTAKeyContext; KeyCode: TShortCut; var BindingResult: TKeyBindingResult);
   public
     function GetBindingType: TBindingType;
     function GetDisplayName: string;
@@ -46,7 +47,7 @@ uses
   Expert.Shortcuts,
   Expert.RenameWizard, Expert.CompletionWizard, Expert.ExtractMethod, Expert.FindReferencesWizard, Expert.FindImplementationsWizard,
   Expert.SignatureCheckWizard, Expert.WithRefactorWizard, Expert.UnitReferencesWizard,
-  Expert.MoveToUnitWizard;
+  Expert.MoveToUnitWizard, Expert.FindOriginalSymbolWizard;
 
 { TLspKeyBinding }
 
@@ -113,6 +114,13 @@ begin
     MoveToUnitInstance.Execute;
 end;
 
+procedure TLspKeyBinding.FindOriginalSymbolKeyProc(const Context: IOTAKeyContext; KeyCode: TShortCut; var BindingResult: TKeyBindingResult);
+begin
+  BindingResult := krHandled;
+  if Assigned(FindOriginalSymbolInstance) then
+    FindOriginalSymbolInstance.Execute;
+end;
+
 function TLspKeyBinding.GetBindingType: TBindingType;
 begin
   Result := btPartial;
@@ -157,6 +165,9 @@ begin
 
   // Ctrl+Shift+M -> Move to unit (project-wide)
   BindingServices.AddKeyBinding([TExpertsShortCut.scMoveToUnit], MoveToUnitKeyProc, nil);
+
+  // Ctrl+G -> Find Original Symbol (Go to Definition)
+  BindingServices.AddKeyBinding([TExpertsShortCut.scFindOriginalSymbol], FindOriginalSymbolKeyProc, nil);
 end;
 
 var

--- a/Source/Expert.OptionsFrame.dfm
+++ b/Source/Expert.OptionsFrame.dfm
@@ -2,13 +2,13 @@ object LspOptionsFrame: TLspOptionsFrame
   Left = 0
   Top = 0
   Width = 520
-  Height = 448
+  Height = 480
   TabOrder = 0
   object grpShortcuts: TGroupBox
     Left = 8
     Top = 8
     Width = 504
-    Height = 320
+    Height = 352
     Caption = ' Keyboard shortcuts '
     TabOrder = 0
     object lblRename: TLabel
@@ -67,9 +67,16 @@ object LspOptionsFrame: TLspOptionsFrame
       Height = 13
       Caption = 'Move to unit (project-wide):'
     end
+    object lblFindOriginalSymbol: TLabel
+      Left = 16
+      Top = 284
+      Width = 100
+      Height = 13
+      Caption = 'Find original symbol:'
+    end
     object lblHint: TLabel
       Left = 16
-      Top = 288
+      Top = 320
       Width = 480
       Height = 13
       Caption =
@@ -149,10 +156,19 @@ object LspOptionsFrame: TLspOptionsFrame
       OnKeyDown = ShortcutEditKeyDown
       OnKeyPress = ShortcutEditKeyPress
     end
+    object edtFindOriginalSymbol: TEdit
+      Left = 160
+      Top = 280
+      Width = 200
+      Height = 21
+      TabOrder = 8
+      OnKeyDown = ShortcutEditKeyDown
+      OnKeyPress = ShortcutEditKeyPress
+    end
   end
   object grpLsp: TGroupBox
     Left = 8
-    Top = 340
+    Top = 372
     Width = 504
     Height = 65
     Caption = ' LSP '
@@ -171,7 +187,7 @@ object LspOptionsFrame: TLspOptionsFrame
   end
   object btnDefaults: TButton
     Left = 8
-    Top = 415
+    Top = 447
     Width = 145
     Height = 25
     Caption = 'Restore defaults'

--- a/Source/Expert.OptionsFrame.pas
+++ b/Source/Expert.OptionsFrame.pas
@@ -40,6 +40,8 @@ type
     edtRemoveWith: TEdit;
     lblMoveToUnit: TLabel;
     edtMoveToUnit: TEdit;
+    lblFindOriginalSymbol: TLabel;
+    edtFindOriginalSymbol: TEdit;
     lblHint: TLabel;
     grpLsp: TGroupBox;
     cbxPrewarmLsp: TCheckBox;
@@ -78,6 +80,7 @@ begin
     skAlign:      Result := edtAlign;
     skRemoveWith: Result := edtRemoveWith;
     skMoveToUnit: Result := edtMoveToUnit;
+    skFindOriginalSymbol: Result := edtFindOriginalSymbol;
   else
     Result := nil;
   end;

--- a/Source/Expert.Registration.pas
+++ b/Source/Expert.Registration.pas
@@ -21,6 +21,7 @@ uses
   Expert.ContextMenu, Expert.UnitRenameWatcher, Expert.LspPrewarmer,
   Expert.WithRefactorWizard,
   Expert.UnitReferencesWizard, Expert.MoveToUnitWizard,
+  Expert.FindOriginalSymbolWizard,
   Expert.Shortcuts, Expert.OptionsPage, Expert.UnitIndex;
 
 type
@@ -72,6 +73,9 @@ begin
   // Create the move-to-unit wizard
   MoveToUnitInstance := TLspMoveToUnitWizard.Create;
 
+  // Create the find-original-symbol wizard
+  FindOriginalSymbolInstance := TLspFindOriginalSymbolWizard.Create;
+
   // Register keyboard shortcuts (defaults are Ctrl+Alt+Shift + R/Space/M/U/I/A,
   // user-configurable via Tools > Options > Refactoring Light).
   InstallKeyBinding;
@@ -111,6 +115,7 @@ finalization
   FreeAndNil(LspPrewarmerInstance);
   FreeAndNil(UnitRenameWatcherInstance);
   FreeAndNil(ContextMenuInstance);
+  FreeAndNil(FindOriginalSymbolInstance);
   FreeAndNil(MoveToUnitInstance);
   FreeAndNil(UnitReferencesInstance);
   FreeAndNil(WithRefactorInstance);

--- a/Source/Expert.Shortcuts.pas
+++ b/Source/Expert.Shortcuts.pas
@@ -24,7 +24,7 @@ uses
   Vcl.Menus;
 
 type
-  TShortcutKind = (skRename, skCompletion, skExtract, skFindRef, skFindImp, skAlign, skRemoveWith, skUnitRefs, skMoveToUnit);
+  TShortcutKind = (skRename, skCompletion, skExtract, skFindRef, skFindImp, skAlign, skRemoveWith, skUnitRefs, skMoveToUnit, skFindOriginalSymbol);
 
   TShortcutChangedProc = procedure of object;
 
@@ -71,6 +71,7 @@ type
     class function scRemoveWith: TShortCut; static;
     class function scUnitRefs: TShortCut; static;
     class function scMoveToUnit: TShortCut; static;
+    class function scFindOriginalSymbol: TShortCut; static;
   end;
 
 implementation
@@ -88,13 +89,15 @@ const
     TShortCut(vkA     or scAlt or scCtrl or scShift),
     TShortCut(vkW     or scAlt or scCtrl or scShift),
     TShortCut(vkF     or scAlt or scCtrl or scShift),
-    TShortCut(vkM     or scCtrl or scShift)
+    TShortCut(vkM     or scCtrl or scShift),
+    TShortCut(vkG     or scCtrl)
   );
 
   ValueNames: array[TShortcutKind] of string = (
     'Rename', 'Completion', 'ExtractMethod',
     'FindReferences', 'FindImplementations', 'AlignSignature',
-    'RemoveWith', 'UnitReferences', 'MoveToUnit'
+    'RemoveWith', 'UnitReferences', 'MoveToUnit',
+    'FindOriginalSymbol'
   );
 
   DisplayNames: array[TShortcutKind] of string = (
@@ -106,7 +109,8 @@ const
     'Align method signature',
     'Remove with (project-wide)',
     'Find unit references (project-wide)',
-    'Move to unit (project-wide)'
+    'Move to unit (project-wide)',
+    'Find original symbol'
   );
 
 { TExpertsShortCut }
@@ -292,6 +296,11 @@ end;
 class function TExpertsShortCut.scMoveToUnit: TShortCut;
 begin
   Result := FShortcuts[skMoveToUnit];
+end;
+
+class function TExpertsShortCut.scFindOriginalSymbol: TShortCut;
+begin
+  Result := FShortcuts[skFindOriginalSymbol];
 end;
 
 end.


### PR DESCRIPTION
## Reason:

Even when the LSP server is responding in Delphi 13.1 it could not always jump to the declaration part of the function that is on the cursor reliably with `Ctrl + Click`.

## Shortcut:

 `Ctrl + G` like the original one